### PR TITLE
Sort mdl values list into (near-)alphabetical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,26 +37,26 @@ You will write in your views:
 `mdl` values are :
 
 ```
-[ 'button',
-  'textfield',
+[ 'badge',
+  'button',
+  'checkbox',
+  'data-table',
+  'dialog',
+  'grid',
+  'icon-toggle',
   'layout',
   'menu',
-  'data-table',
-  'tabs',
-  'slider',
-  'tooltip',
-  'progress',
-  'spinner',
-  'badge',
-  'switch',
-  'radio',
-  'icon-toggle',
-  'checkbox',
-  'dialog',
   'mega-footer',
   'mini-footer',
-  'grid',
-  'snackbar' ]
+  'progress',
+  'radio',
+  'slider',
+  'snackbar',
+  'spinner',
+  'switch',
+  'tabs',
+  'textfield',
+  'tooltip' ]
 ```
 ### Events
 


### PR DESCRIPTION
The list is now in alphabetical order, to make things easier to find, with the exception of `menu` which was push one row up, so that the two footer types would be adjacent to each other.

Why? Because I found I was scanning this list often, and its random order was a cognitive barrier to efficiency.
